### PR TITLE
修改db2执行创建表失败后执行的逻辑

### DIFF
--- a/lib/dialects/db2/query.js
+++ b/lib/dialects/db2/query.js
@@ -223,6 +223,7 @@ class Query extends AbstractQuery {
         } else {
           table = `"${  mtarray[0]  }"`;
         }
+        // sugo modify 兰哒
         // connection.querySync(`DROP TABLE ${ table }`);
         // err = connection.querySync(sql);
         err = null

--- a/lib/dialects/db2/query.js
+++ b/lib/dialects/db2/query.js
@@ -223,8 +223,9 @@ class Query extends AbstractQuery {
         } else {
           table = `"${  mtarray[0]  }"`;
         }
-        connection.querySync(`DROP TABLE ${ table }`);
-        err = connection.querySync(sql);
+        // connection.querySync(`DROP TABLE ${ table }`);
+        // err = connection.querySync(sql);
+        err = null
       } else {
         err = null; // Ignore create schema error.
       }


### PR DESCRIPTION
针对db2数据库执行创表语句，当表存在时会删除表的逻辑,修改为创建已存在的表不执行删表逻辑